### PR TITLE
Remove excessive margin on walkthrough page

### DIFF
--- a/docs/.vuepress/public/examples/walkthrough.html
+++ b/docs/.vuepress/public/examples/walkthrough.html
@@ -16,7 +16,7 @@
     </style>
 </head>
 <body>
-<section class="section">
+<section>
     <div class="container">
         <section id="setup">
             <label class="label">Sandbox Publishable API Key</label>


### PR DESCRIPTION
Remove excessive margin on walkthrough page which adds too much padding in the page when embedded via iframe.