### PR TITLE
Speedup configuration and examples page

### DIFF
--- a/docs/configuration/properties.md
+++ b/docs/configuration/properties.md
@@ -28,7 +28,16 @@ All supported locales are available in the `Rebilly.locales.*` namespace.
 </table>
 
 :::: tabs
-::: tab result
+::: tab javascript
+<<< @/docs/.vuepress/public/examples/example-locale-1/index.js
+:::
+::: tab html
+<<< @/docs/.vuepress/public/examples/example-locale-1/index.html
+:::
+::: tab css
+<<< @/docs/.vuepress/public/examples/example-locale-1/index.css
+:::
+::: tab result lazy
 <iframe 
     style="margin-bottom: 8px;" border="0" 
     frameborder="0"
@@ -41,15 +50,6 @@ All supported locales are available in the `Rebilly.locales.*` namespace.
     href="https://github.com/Rebilly/framepay-docs/blob/master/docs/.vuepress/public/examples/example-locale-1/index.html">
         View source on GitHub
     </a>
-:::
-::: tab html
-<<< @/docs/.vuepress/public/examples/example-locale-1/index.html
-:::
-::: tab javascript
-<<< @/docs/.vuepress/public/examples/example-locale-1/index.js
-:::
-::: tab css
-<<< @/docs/.vuepress/public/examples/example-locale-1/index.css
 :::
 ::::
 
@@ -87,7 +87,16 @@ This property will let you control the visibility of the icon in the card and ib
 </table> 
 
 :::: tabs
-::: tab result
+::: tab javascript
+<<< @/docs/.vuepress/public/examples/example-icon-1/index.js
+:::
+::: tab html
+<<< @/docs/.vuepress/public/examples/example-icon-1/index.html
+:::
+::: tab css
+<<< @/docs/.vuepress/public/examples/example-icon-1/index.css
+:::
+::: tab result lazy
 <iframe 
     style="margin-bottom: 8px;" border="0" 
     frameborder="0"
@@ -100,15 +109,6 @@ This property will let you control the visibility of the icon in the card and ib
     href="https://github.com/Rebilly/framepay-docs/blob/master/docs/.vuepress/public/examples/example-icon-1/index.html">
         View source on GitHub
     </a>
-:::
-::: tab html
-<<< @/docs/.vuepress/public/examples/example-icon-1/index.html
-:::
-::: tab javascript
-<<< @/docs/.vuepress/public/examples/example-icon-1/index.js
-:::
-::: tab css
-<<< @/docs/.vuepress/public/examples/example-icon-1/index.css
 :::
 ::::
 
@@ -132,7 +132,16 @@ This property will let you control the color of the icon in the card and iban fi
 
 #### Card element
 :::: tabs
-::: tab result
+::: tab javascript
+<<< @/docs/.vuepress/public/examples/example-icon-2/index.js
+:::
+::: tab html
+<<< @/docs/.vuepress/public/examples/example-icon-2/index.html
+:::
+::: tab css
+<<< @/docs/.vuepress/public/examples/example-icon-2/index.css
+:::
+::: tab result lazy
 <iframe 
     style="margin-bottom: 8px;" border="0" 
     frameborder="0"
@@ -146,20 +155,20 @@ This property will let you control the color of the icon in the card and iban fi
         View source on GitHub
     </a>
 :::
-::: tab html
-<<< @/docs/.vuepress/public/examples/example-icon-2/index.html
-:::
-::: tab javascript
-<<< @/docs/.vuepress/public/examples/example-icon-2/index.js
-:::
-::: tab css
-<<< @/docs/.vuepress/public/examples/example-icon-2/index.css
-:::
 ::::
 
 #### IBAN element
 :::: tabs
-::: tab result
+::: tab javascript
+<<< @/docs/.vuepress/public/examples/example-icon-3/index.js
+:::
+::: tab html
+<<< @/docs/.vuepress/public/examples/example-icon-3/index.html
+:::
+::: tab css
+<<< @/docs/.vuepress/public/examples/example-icon-3/index.css
+:::
+::: tab result lazy
 <iframe 
     style="margin-bottom: 8px;" border="0" 
     frameborder="0"
@@ -172,15 +181,6 @@ This property will let you control the color of the icon in the card and iban fi
     href="https://github.com/Rebilly/framepay-docs/blob/master/docs/.vuepress/public/examples/example-icon-3/index.html">
         View source on GitHub
     </a>
-:::
-::: tab html
-<<< @/docs/.vuepress/public/examples/example-icon-3/index.html
-:::
-::: tab javascript
-<<< @/docs/.vuepress/public/examples/example-icon-3/index.js
-:::
-::: tab css
-<<< @/docs/.vuepress/public/examples/example-icon-3/index.css
 :::
 ::::
 
@@ -205,21 +205,17 @@ The [card](../reference/rebilly.md#rebilly-card-mount) element placeholders.
     <tr><td>Type</td><td>Object</td></tr>
 </table>
 
-```javascript
-Rebilly.initialize({
-    publishableKey: 'pk_sandbox_1234567890',
-    placeholders: {
-        card: {
-            number: 'Number',
-            expiry: 'Exp',
-            cvv: '***',
-        },
-    },
-}); 
-```
-
 :::: tabs
-::: tab result
+::: tab javascript
+<<< @/docs/.vuepress/public/examples/example-placeholders-1/index.js
+:::
+::: tab html
+<<< @/docs/.vuepress/public/examples/example-placeholders-1/index.html
+:::
+::: tab css
+<<< @/docs/.vuepress/public/examples/example-placeholders-1/index.css
+:::
+::: tab result lazy
 <iframe 
     style="margin-bottom: 8px;" border="0" 
     frameborder="0"
@@ -232,15 +228,6 @@ Rebilly.initialize({
     href="https://github.com/Rebilly/framepay-docs/blob/master/docs/.vuepress/public/examples/example-placeholders-1/index.html">
         View source on GitHub
     </a>
-:::
-::: tab html
-<<< @/docs/.vuepress/public/examples/example-placeholders-1/index.html
-:::
-::: tab javascript
-<<< @/docs/.vuepress/public/examples/example-placeholders-1/index.js
-:::
-::: tab css
-<<< @/docs/.vuepress/public/examples/example-placeholders-1/index.css
 :::
 ::::
 
@@ -262,7 +249,16 @@ Rebilly.initialize({
 :::
 
 :::: tabs
-::: tab result
+::: tab javascript
+<<< @/docs/.vuepress/public/examples/example-placeholders-1-2/index.js
+:::
+::: tab html
+<<< @/docs/.vuepress/public/examples/example-placeholders-1-2/index.html
+:::
+::: tab css
+<<< @/docs/.vuepress/public/examples/example-placeholders-1-2/index.css
+:::
+::: tab result lazy
 <iframe 
     style="margin-bottom: 8px;" border="0" 
     frameborder="0"
@@ -275,15 +271,6 @@ Rebilly.initialize({
         View source on GitHub
     </a>
 :::
-::: tab html
-<<< @/docs/.vuepress/public/examples/example-placeholders-1-2/index.html
-:::
-::: tab javascript
-<<< @/docs/.vuepress/public/examples/example-placeholders-1-2/index.js
-:::
-::: tab css
-<<< @/docs/.vuepress/public/examples/example-placeholders-1-2/index.css
-:::
 ::::
 
 
@@ -291,7 +278,16 @@ Rebilly.initialize({
 The [bankAccount](../reference/rebilly.md#rebilly-bankaccount-mount) element placeholder
 
 :::: tabs
-::: tab result
+::: tab javascript
+<<< @/docs/.vuepress/public/examples/example-placeholders-2/index.js
+:::
+::: tab html
+<<< @/docs/.vuepress/public/examples/example-placeholders-2/index.html
+:::
+::: tab css
+<<< @/docs/.vuepress/public/examples/example-placeholders-2/index.css
+:::
+::: tab result lazy
 <iframe 
     style="margin-bottom: 8px;" border="0" 
     frameborder="0"
@@ -305,21 +301,21 @@ The [bankAccount](../reference/rebilly.md#rebilly-bankaccount-mount) element pla
         View source on GitHub
     </a>
 :::
-::: tab html
-<<< @/docs/.vuepress/public/examples/example-placeholders-2/index.html
-:::
-::: tab javascript
-<<< @/docs/.vuepress/public/examples/example-placeholders-2/index.js
-:::
-::: tab css
-<<< @/docs/.vuepress/public/examples/example-placeholders-2/index.css
-:::
 ::::
 
 ### iban
 The [iban](../reference/rebilly.md#rebilly-iban-mount) element placeholder
 :::: tabs
-::: tab result
+::: tab javascript
+<<< @/docs/.vuepress/public/examples/example-placeholders-3/index.js
+:::
+::: tab html
+<<< @/docs/.vuepress/public/examples/example-placeholders-3/index.html
+:::
+::: tab css
+<<< @/docs/.vuepress/public/examples/example-placeholders-3/index.css
+:::
+::: tab result lazy
 <iframe 
     style="margin-bottom: 8px;" border="0" 
     frameborder="0"
@@ -332,15 +328,6 @@ The [iban](../reference/rebilly.md#rebilly-iban-mount) element placeholder
     href="https://github.com/Rebilly/framepay-docs/blob/master/docs/.vuepress/public/examples/example-placeholders-3/index.html">
         View source on GitHub
     </a>
-:::
-::: tab html
-<<< @/docs/.vuepress/public/examples/example-placeholders-3/index.html
-:::
-::: tab javascript
-<<< @/docs/.vuepress/public/examples/example-placeholders-3/index.js
-:::
-::: tab css
-<<< @/docs/.vuepress/public/examples/example-placeholders-3/index.css
 :::
 ::::
 
@@ -423,7 +410,16 @@ This array allows you to customize the available card types in the card field
 </table>
 
 :::: tabs
-::: tab result
+::: tab javascript
+<<< @/docs/.vuepress/public/examples/example-allowed-card-brands-1/index.js
+:::
+::: tab html
+<<< @/docs/.vuepress/public/examples/example-allowed-card-brands-1/index.html
+:::
+::: tab css
+<<< @/docs/.vuepress/public/examples/example-allowed-card-brands-1/index.css
+:::
+::: tab result lazy
 - Visa (allowed) `4111111111111111`
 - MasterCard (declined) `5555555555554444`
 - AMEX (allowed) `378282246310005`
@@ -440,15 +436,6 @@ This array allows you to customize the available card types in the card field
     href="https://github.com/Rebilly/framepay-docs/blob/master/docs/.vuepress/public/examples/example-allowed-card-brands-1/index.html">
         View source on GitHub
     </a>
-:::
-::: tab html
-<<< @/docs/.vuepress/public/examples/example-allowed-card-brands-1/index.html
-:::
-::: tab javascript
-<<< @/docs/.vuepress/public/examples/example-allowed-card-brands-1/index.js
-:::
-::: tab css
-<<< @/docs/.vuepress/public/examples/example-allowed-card-brands-1/index.css
 :::
 ::::
 
@@ -468,7 +455,16 @@ The card expiry field supports 2 render types.
 </table>
 
 :::: tabs
-::: tab result
+::: tab javascript
+<<< @/docs/.vuepress/public/examples/example-expiry-dropdown-1/index.js
+:::
+::: tab html
+<<< @/docs/.vuepress/public/examples/example-expiry-dropdown-1/index.html
+:::
+::: tab css
+<<< @/docs/.vuepress/public/examples/example-expiry-dropdown-1/index.css
+:::
+::: tab result lazy
 <iframe 
     style="margin-bottom: 8px;" border="0" 
     frameborder="0"
@@ -481,20 +477,20 @@ The card expiry field supports 2 render types.
         View source on GitHub
     </a>
 :::
-::: tab html
-<<< @/docs/.vuepress/public/examples/example-expiry-dropdown-1/index.html
-:::
-::: tab javascript
-<<< @/docs/.vuepress/public/examples/example-expiry-dropdown-1/index.js
-:::
-::: tab css
-<<< @/docs/.vuepress/public/examples/example-expiry-dropdown-1/index.css
-:::
 ::::
 
 #### Expiry dropdown card separated style
 :::: tabs
-::: tab result
+::: tab javascript
+<<< @/docs/.vuepress/public/examples/example-expiry-dropdown-2/index.js
+:::
+::: tab html
+<<< @/docs/.vuepress/public/examples/example-expiry-dropdown-2/index.html
+:::
+::: tab css
+<<< @/docs/.vuepress/public/examples/example-expiry-dropdown-2/index.css
+:::
+::: tab result lazy
 <iframe 
     style="margin-bottom: 8px;" border="0" 
     frameborder="0"
@@ -506,15 +502,6 @@ The card expiry field supports 2 render types.
     href="https://github.com/Rebilly/framepay-docs/blob/master/docs/.vuepress/public/examples/example-expiry-dropdown-2/index.html">
         View source on GitHub
     </a>
-:::
-::: tab html
-<<< @/docs/.vuepress/public/examples/example-expiry-dropdown-2/index.html
-:::
-::: tab javascript
-<<< @/docs/.vuepress/public/examples/example-expiry-dropdown-2/index.js
-:::
-::: tab css
-<<< @/docs/.vuepress/public/examples/example-expiry-dropdown-2/index.css
 :::
 ::::
 
@@ -534,7 +521,16 @@ The card cvv field supports 2 render types.
 </table>
 
 :::: tabs
-::: tab result
+::: tab javascript
+<<< @/docs/.vuepress/public/examples/example-cvv-1/index.js
+:::
+::: tab html
+<<< @/docs/.vuepress/public/examples/example-cvv-1/index.html
+:::
+::: tab css
+<<< @/docs/.vuepress/public/examples/example-cvv-1/index.css
+:::
+::: tab result lazy
 <iframe 
     style="margin-bottom: 8px;" border="0" 
     frameborder="0"
@@ -546,15 +542,6 @@ The card cvv field supports 2 render types.
     href="https://github.com/Rebilly/framepay-docs/blob/master/docs/.vuepress/public/examples/example-cvv-1/index.html">
         View source on GitHub
     </a>
-:::
-::: tab html
-<<< @/docs/.vuepress/public/examples/example-cvv-1/index.html
-:::
-::: tab javascript
-<<< @/docs/.vuepress/public/examples/example-cvv-1/index.js
-:::
-::: tab css
-<<< @/docs/.vuepress/public/examples/example-cvv-1/index.css
 :::
 ::::
 
@@ -573,7 +560,13 @@ This object can customize the look of elements using these keys:
 - `invalid`, validation state applied when the data within is incorrect or incomplete, and after user interaction
 
 :::: tabs
-::: tab result
+::: tab javascript
+<<< @/docs/.vuepress/public/examples/example-style-1/index.js
+:::
+::: tab html
+<<< @/docs/.vuepress/public/examples/example-style-1/index.html
+:::
+::: tab result lazy
 <iframe 
     style="margin-bottom: 8px;" border="0" 
     frameborder="0"
@@ -585,12 +578,6 @@ This object can customize the look of elements using these keys:
     href="https://github.com/Rebilly/framepay-docs/blob/master/docs/.vuepress/public/examples/example-style-1/index.html">
         View source on GitHub
     </a>
-:::
-::: tab html
-<<< @/docs/.vuepress/public/examples/example-style-1/index.html
-:::
-::: tab javascript
-<<< @/docs/.vuepress/public/examples/example-style-1/index.js
 :::
 ::::
 
@@ -623,7 +610,13 @@ The <code>base</code>, <code>focus</code> and <code>active</code> button states 
 </ul>
 
 :::: tabs
-::: tab result
+::: tab javascript
+<<< @/docs/.vuepress/public/examples/example-buttons-1/index.js
+:::
+::: tab html
+<<< @/docs/.vuepress/public/examples/example-buttons-1/index.html
+:::
+::: tab result lazy
 <iframe 
     style="margin-bottom: 8px;" border="0" 
     frameborder="0"
@@ -636,12 +629,6 @@ The <code>base</code>, <code>focus</code> and <code>active</code> button states 
     href="https://github.com/Rebilly/framepay-docs/blob/master/docs/.vuepress/public/examples/example-buttons-1/index.html">
         View source on GitHub
     </a>
-:::
-::: tab html
-<<< @/docs/.vuepress/public/examples/example-buttons-1/index.html
-:::
-::: tab javascript
-<<< @/docs/.vuepress/public/examples/example-buttons-1/index.js
 :::
 ::::
 
@@ -740,7 +727,16 @@ An object defining custom class names for the fields that were injected into you
 
 
 :::: tabs
-::: tab result
+::: tab javascript
+<<< @/docs/.vuepress/public/examples/example-classes-1/index.js
+:::
+::: tab html
+<<< @/docs/.vuepress/public/examples/example-classes-1/index.html
+:::
+::: tab css
+<<< @/docs/.vuepress/public/examples/example-classes-1/index.css
+:::
+::: tab result lazy
 <iframe 
     style="margin-bottom: 8px;" border="0" 
     frameborder="0"
@@ -752,14 +748,5 @@ An object defining custom class names for the fields that were injected into you
     href="https://github.com/Rebilly/framepay-docs/blob/master/docs/.vuepress/public/examples/example-classes-1/index.html">
         View source on GitHub
     </a>
-:::
-::: tab html
-<<< @/docs/.vuepress/public/examples/example-classes-1/index.html
-:::
-::: tab javascript
-<<< @/docs/.vuepress/public/examples/example-classes-1/index.js
-:::
-::: tab css
-<<< @/docs/.vuepress/public/examples/example-classes-1/index.css
 :::
 ::::

--- a/docs/examples/payment-card/expiry-dropdown.md
+++ b/docs/examples/payment-card/expiry-dropdown.md
@@ -1,0 +1,5 @@
+## Expiry dropdown
+<br>
+<iframe style="margin-bottom: 8px;height:500px;" border="0" frameborder="0" height="500" scrolling="no" src="/framepay-docs/examples/example2-1.html"></iframe>
+<a target="_blank" href="example2-1.html" style="display: block; text-align: right;">View Example</a>
+<a href="https://github.com/Rebilly/framepay-docs/blob/master/docs/.vuepress/public/examples/example2-1.html" style="margin-bottom: 60px; display: block; text-align: right;">View source on GitHub</a>

--- a/docs/examples/payment-card/fullname-field.md
+++ b/docs/examples/payment-card/fullname-field.md
@@ -1,0 +1,5 @@
+## FullName field
+<br>
+<iframe style="margin-bottom: 8px;height:500px;" border="0" frameborder="0" height="500" scrolling="no" src="/framepay-docs/examples/example2-0.html"></iframe>
+<a target="_blank" href="example2-0.html" style="display: block; text-align: right;">View Example</a>
+<a href="https://github.com/Rebilly/framepay-docs/blob/master/docs/.vuepress/public/examples/example2-0.html" style="margin-bottom: 60px; display: block; text-align: right;">View source on GitHub</a>

--- a/docs/examples/payment-card/separated-card-fields.md
+++ b/docs/examples/payment-card/separated-card-fields.md
@@ -1,0 +1,5 @@
+## Separated fields
+<br>
+<iframe style="margin-bottom: 8px;height:660px;" border="0" frameborder="0" height="660" scrolling="no" src="/framepay-docs/examples/example4.html"></iframe>
+<a target="_blank" href="example4.html" style="display: block; text-align: right;">View Example</a>
+<a href="https://github.com/Rebilly/framepay-docs/blob/master/docs/.vuepress/public/examples/example4.html" style="margin-bottom: 60px; display: block; text-align: right;">View source on GitHub</a>

--- a/docs/examples/payment-card/separated-fields-expiry-dropdown.md
+++ b/docs/examples/payment-card/separated-fields-expiry-dropdown.md
@@ -1,0 +1,5 @@
+## Separated fields and expiry dropdown
+<br>
+<iframe style="margin-bottom: 8px;height:660px;" border="0" frameborder="0" height="660" scrolling="no" src="/framepay-docs/examples/example4-1.html"></iframe>
+<a target="_blank" href="example4-1.html" style="display: block; text-align: right;">View Example</a>
+<a href="https://github.com/Rebilly/framepay-docs/blob/master/docs/.vuepress/public/examples/example4-1.html" style="margin-bottom: 60px; display: block; text-align: right;">View source on GitHub</a>

--- a/docs/examples/payment-card/styled.md
+++ b/docs/examples/payment-card/styled.md
@@ -1,0 +1,5 @@
+## Styled
+<br>
+<iframe style="margin-bottom: 8px;height:500px;" border="0" frameborder="0" height="500" scrolling="no" src="/framepay-docs/examples/example3.html"></iframe>
+<a target="_blank" href="example3.html" style="display: block; text-align: right;">View Example</a>
+<a href="https://github.com/Rebilly/framepay-docs/blob/master/docs/.vuepress/public/examples/example3.html" style="margin-bottom: 60px; display: block; text-align: right;">View source on GitHub</a>

--- a/docs/examples/payment-cards.md
+++ b/docs/examples/payment-cards.md
@@ -1,36 +1,15 @@
-## Base
+### Basic Payment Card
 <br>
 <iframe style="margin-bottom: 8px;height:500px;" border="0" frameborder="0" height="500" scrolling="no" src="/framepay-docs/examples/example2.html"></iframe>
 <a target="_blank" href="example2.html" style="display: block; text-align: right;">View Example</a>
 <a href="https://github.com/Rebilly/framepay-docs/blob/master/docs/.vuepress/public/examples/example2.html" style="margin-bottom: 60px; display: block; text-align: right;">View source on GitHub</a>
 
-## FullName field
-<br>
-<iframe style="margin-bottom: 8px;height:500px;" border="0" frameborder="0" height="500" scrolling="no" src="/framepay-docs/examples/example2-0.html"></iframe>
-<a target="_blank" href="example2-0.html" style="display: block; text-align: right;">View Example</a>
-<a href="https://github.com/Rebilly/framepay-docs/blob/master/docs/.vuepress/public/examples/example2-0.html" style="margin-bottom: 60px; display: block; text-align: right;">View source on GitHub</a>
+--- 
 
-## Expiry dropdown
-<br>
-<iframe style="margin-bottom: 8px;height:500px;" border="0" frameborder="0" height="500" scrolling="no" src="/framepay-docs/examples/example2-1.html"></iframe>
-<a target="_blank" href="example2-1.html" style="display: block; text-align: right;">View Example</a>
-<a href="https://github.com/Rebilly/framepay-docs/blob/master/docs/.vuepress/public/examples/example2-1.html" style="margin-bottom: 60px; display: block; text-align: right;">View source on GitHub</a>
-
-
-## Styled
-<br>
-<iframe style="margin-bottom: 8px;height:500px;" border="0" frameborder="0" height="500" scrolling="no" src="/framepay-docs/examples/example3.html"></iframe>
-<a target="_blank" href="example3.html" style="display: block; text-align: right;">View Example</a>
-<a href="https://github.com/Rebilly/framepay-docs/blob/master/docs/.vuepress/public/examples/example3.html" style="margin-bottom: 60px; display: block; text-align: right;">View source on GitHub</a>
-
-## Separated fields
-<br>
-<iframe style="margin-bottom: 8px;height:660px;" border="0" frameborder="0" height="660" scrolling="no" src="/framepay-docs/examples/example4.html"></iframe>
-<a target="_blank" href="example4.html" style="display: block; text-align: right;">View Example</a>
-<a href="https://github.com/Rebilly/framepay-docs/blob/master/docs/.vuepress/public/examples/example4.html" style="margin-bottom: 60px; display: block; text-align: right;">View source on GitHub</a>
-
-## Separated fields and expiry dropdown
-<br>
-<iframe style="margin-bottom: 8px;height:660px;" border="0" frameborder="0" height="660" scrolling="no" src="/framepay-docs/examples/example4-1.html"></iframe>
-<a target="_blank" href="example4-1.html" style="display: block; text-align: right;">View Example</a>
-<a href="https://github.com/Rebilly/framepay-docs/blob/master/docs/.vuepress/public/examples/example4-1.html" style="margin-bottom: 60px; display: block; text-align: right;">View source on GitHub</a>
+::: tip Additional examples
+- [Card with fullName field](./payment-card/fullname-field.md) <small>Card with one input fullName</small>
+- [Expiry DropDown](./payment-card/expiry-dropdown.md) <small>Card with expiry year and month dropdown fields</small>
+- [Styled Example](./payment-card/styled.md) <small>Styled card element</small>
+- [Separated fields](./payment-card/separated-card-fields.md) <small>Card with separated field cardNumber, cardExpiry and cardCvv</small>
+- [Separated fields and expiry DropDown](./payment-card/separated-fields-expiry-dropdown.md) <small>Separated card with expiry dropdown</small>
+:::


### PR DESCRIPTION
### Checks:
* [x] Have you checked the dependencies list?
* [x] Have you checked the examples page?
* [x] Have you checked the build command?
* [x] Have you checked with the default environment configuration?

### Description
Update configuration and examples page (speedup)

### Changes
Add lazy-load result tab property on the configuration page 
Make the javascript tab as the tab by default
Create separated pages with card examples

![card-examples](https://user-images.githubusercontent.com/4567083/67120380-ddac9c00-f1f1-11e9-831e-c4aa60224e81.gif)

